### PR TITLE
--rounds flag

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -18,15 +18,15 @@ switch (inputArg) {
         "",
         "Usage:",
         "",
-        "   elm-minify <input>",
+        "   elm-minify <input> [--rounds=<rounds>]",
         "",
-        "Inputs:",
+        "<input>:               Defaults to 'dist/index.js'",
         "",
         "   <filepath>.js       Minify to <filepath>.min.js",
         "   --version           Show package version",
         "   --help              Show this help message",
         "",
-        "   If no <input> is specified, 'dist/index.js' is used",
+        "<rounds>               Number of compression rounds. Defaults to 2.",
         ""
     ].join("\n"))
 


### PR DESCRIPTION
As per #6, compression results can improve by running multiple rounds. Defaulting to 2, this flag can be set based on what makes sense for you.