### PR TITLE
--extra-round flag enabled, bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "elm-minify",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elm-minify",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Minify compiled Elm modules!",
   "bin": {
     "elm-minify": "src/cli.js"

--- a/src/cli.js
+++ b/src/cli.js
@@ -7,6 +7,7 @@ var pkg = require("../package.json")
 var lib = require("./lib.js")
 
 var inputArg = process.argv[2]
+var extraRoundArg = process.argv.indexOf("--extra-round") !== -1
 
 switch (inputArg) {
 
@@ -20,13 +21,14 @@ switch (inputArg) {
         "",
         "   elm-minify <input>",
         "",
-        "Inputs:",
+        "<input>:                   Defaults to 'dist/index.js'",
         "",
-        "   <filepath>.js       Minify to <filepath>.min.js",
-        "   --version           Show package version",
-        "   --help              Show this help message",
+        "   <filepath>.js           Minify to <filepath>.min.js",
         "",
-        "   If no <input> is specified, 'dist/index.js' is used",
+        "       [--extra-round]     Run an additional round of compression",
+        "",
+        "   --version                       Show package version",
+        "   --help                          Show this help message",
         ""
     ].join("\n"))
 
@@ -47,7 +49,7 @@ var compressionResult = ujs.minify(inputCode, {
         keep_fargs: false,
         unsafe_comps: true,
         unsafe: true,
-        passes: 2
+        passes: extraRoundArg ? 3 : 2
     }
 })
 


### PR DESCRIPTION
As per #6, compression results can improve by running an additional round of it. This is now enabled with the `--extra-round`-flag.